### PR TITLE
silence output of qbt_login, fix #4

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-gluetun-sync-port/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-gluetun-sync-port/run
@@ -37,7 +37,7 @@ log(){
 
 
 qbt_login(){
-  curl --fail --silent \
+  curl --fail --silent --output /dev/null \
       ${QBT_COOKIES} \
       --url "${QBITTORRENT}/api/v2/auth/login" \
       --data "username=${QBT_USERNAME}" \


### PR DESCRIPTION
I believe this is a fix for https://github.com/t-anc/GSP-Qbittorent-Gluetun-sync-port-mod/issues/4, the "Ok." was the output coming out of the qbt_login call to curl, resulting in the "Ok.200" seen. Unfortunately been struggling to test this due to issues getting the image to pull my forked mod image through the vpn, but I am pretty sure this is the fix.