### PR TITLE
Add more info about Gluetun control server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ With the following link for the mod `ghcr.io/t-anc/gsp-qbittorent-gluetun-sync-p
 - If you have enabled the `Enable Host header validation` option, you will need to add `localhost` to the `Server domains` list.
 
 ### Gluetun
-You will need to add the following lines to your [config.toml](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication) :
+You will need to enable the Control Server in Gluetun. Follow the instructions [here](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md).
+
+Then add the following lines to your [config.toml](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication) :
 
 ```toml
 [[roles]]
 name = "t-anc/GSP-Qbittorent-Gluetun-sync-port-mod"
 routes = ["GET /v1/openvpn/portforwarded"]
 auth = "apikey"
-# This is an example, generate your own. See bellow.
+# This is an example, generate your own. See below for examples.
 apikey = "yOdKVNFEA3/BSIWhPZohxppHd9I6bHiSJ+FasGlncleveW4LvuO7ONy5w1IsEA2Pu6s="
 ```
 You can generate your own API key with one of the following command :


### PR DESCRIPTION
When I first read through the README, I wasn't clear who the `config.toml` file belonged to (i.e. was it a Gluetun file or a GSP file). I hadn't needed to use the control server, so I wasn't even aware it was a thing in Gluetun.

This change I'm proposing is to point out the existence of the control server on Gluetun and link out to its documentation. This way future readers in my situation can have better context of the next sentence in this README.

I know that the `config.toml` words link out to the specific section of the Gluetun documentation, but I didn't even think to click on that link on my first read-through because I assumed it was linking to a file in this repo, which is probably why I wasn't sure if `config.toml` belonged to Gluetun or GSP.