### PR TITLE
Fix compose example typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ services:
         image: qmcgaw/gluetun
         container_name: gluetun
         restart: always
-        port:
+        ports:
           - 8080:8080 # Qbt exposed webUI
         cap_add:
           - NET_ADMIN
@@ -183,7 +183,7 @@ services:
         volumes:
           - "./qbittorrent/config/:/config"
           - "./qbittorrent/webui/:/webui"
-          - "./download:/download"
+          - "./download:/downloads"
         network_mode: container:gluetun
         depends_on:
           gluetun:


### PR DESCRIPTION
Ran across some issues with typos when playing around with the example compose file.

I also needed to add a device section, but not sure if that was due to my use case. So for this PR I'm just fixing the typos.